### PR TITLE
Loosen Web3 from 4.0b7 to >=4.0.0,<5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras_require['dev'] = (
 )
 
 install_requires = [
-    'web3~=4.0b7',
+    'web3>=4.0.0,<5.0.0',
 ]
 if sys.platform == 'win32':
     install_requires.append('pypiwin32')


### PR DESCRIPTION
## What was wrong?

Issue #2 

## How was it fixed?

Loosened the restriction to allow all 4.x Web3.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/aaqzPMOd_1g/maxresdefault.jpg)
