### PR TITLE
Bump web3 to 5.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import (
 
 extras_require={
     'test': [
-        "pytest==3.3.2",
+        "pytest>=3.6.0",
         "tox>=2.9.1,<3",
     ],
     'lint': [
@@ -38,7 +38,7 @@ extras_require['dev'] = (
 )
 
 install_requires = [
-    'web3>=4.0.0,<5.0.0',
+    'web3>=5.0.0a1,<6.0.0',
 ]
 if sys.platform == 'win32':
     install_requires.append('pypiwin32')


### PR DESCRIPTION
## What was wrong?

Fixing dependency warnings found in https://github.com/ethereum/web3.py/issues/829 (see [here](https://github.com/ethereum/web3.py/issues/829#issuecomment-449801746)).

## How was it fixed?

Try to align pytest across projects, allow ethtoken to be on 5.x alpha.

This blocks https://github.com/ethereum/web3.py/pull/1175

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://img.buzzfeed.com/buzzfeed-static/static/2014-04/enhanced/webdr06/14/12/enhanced-buzz-31894-1397491386-8.jpg?downsize=700:*&output-format=auto&output-quality=auto)
