### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-core
+  py37-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-core
 workflows:
   version: 2
   test:
@@ -49,3 +55,4 @@ workflows:
       - lint
       - py35-core
       - py36-core
+      - py37-core

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ output/*/index.html
 
 # Sphinx
 docs/_build
+docs/modules.rst
+docs/ethtoken.*
 
 # Blockchain
 chains

--- a/ethtoken/main.py
+++ b/ethtoken/main.py
@@ -1,10 +1,18 @@
 
-from decimal import Decimal
+from decimal import (
+    Decimal,
+)
 
-from cytoolz import curry
-from web3.contract import ConciseContract
+from cytoolz import (
+    curry,
+)
+from web3.contract import (
+    ConciseContract,
+)
 
-from ethtoken.abi import EIP20_ABI
+from ethtoken.abi import (
+    EIP20_ABI,
+)
 
 
 @curry

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import (
 
 extras_require={
     'test': [
-        "pytest==3.3.2",
+        "pytest>=3.6.0",
         "tox>=2.9.1,<3",
     ],
     'lint': [
@@ -55,6 +55,7 @@ setup(
     include_package_data=True,
     install_requires=install_requires,
     setup_requires=['setuptools-markdown'],
+    python_requires='>=3.5,<4',
     extras_require=extras_require,
     py_modules=['ethtoken'],
     license="MIT",
@@ -69,5 +70,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{35,36}-core
+    py{35,36,37}-core
     lint
 
 [isort]
@@ -25,6 +25,7 @@ commands=
 basepython =
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 extras=test
 
 [testenv:lint]


### PR DESCRIPTION
## What was wrong?

Resolves Issue #5 

## How was it fixed?

Added support for Python 3.7 in CI builds, made support explicit in classifiers.

**NOTE:** We should merge #4 first to separate concerns.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/iL1Dbfz7Mok/maxresdefault.jpg)