### PR TITLE
Bump web3 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras_require['dev'] = (
 )
 
 install_requires = [
-    'web3>=4.0.0,<5.0.0',
+    'web3>=4.0.0,<6.0.0',
 ]
 if sys.platform == 'win32':
     install_requires.append('pypiwin32')


### PR DESCRIPTION
## What was wrong?

web3<5.0.0 requirement conflicts with some other packages
Issue #7 

## How was it fixed?

Replace the version of latest version to web3 v6.0.0

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://lh3.googleusercontent.com/proxy/KGlpxdFqYCiyU94oStDBP2-f3K_tcBGdZd6YGGaoJvFJ3LIrKrqHNk6NNvn3LxoWN17Cyfjjxi6QcTaWWFz2rgKB18zoFvSbx45Wc776BwnS5lBgx3Z5bZejJy8UrYhyq_IU0LE2S6NsZWK8R_OxrVkemNQq)
