### PR TITLE
Fixing broken links to EIP-20 standard to use Preferred Citation Form…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ethtoken.py
 
 This is a tiny library leveraging web3.py to make an interface for
-working with [EIP20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md)
+working with [EIP20](https://eips.ethereum.org/EIPS/eip-20)
 tokens on Ethereum. (formerly ERC20)
 
 **It is currently in Alpha, with 0 automated tests**

--- a/ethtoken/main.py
+++ b/ethtoken/main.py
@@ -23,7 +23,7 @@ def eip20_tokenBalanceOf(token, address):
 def eip20_token(address, w3=None, **kwargs):
     '''
     :param address: `EIP20
-        <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md>`_
+        <https://eips.ethereum.org/EIPS/eip-20>`_
         token contract
     :type address: ENS name or hex str
     :param `Web3 <http://web3py.readthedocs.io/en/latest/quickstart.html#using-web3>`_ w3:


### PR DESCRIPTION
…at <https://github.com/ethereum/EIPs/blob/a53796fb48328ec3c491e1222b6e707801e4fe87/README.md#preferred-citation-format>.

## What was wrong?

Links to the EIP-20 document in the code and documentation were broken.

## How was it fixed?

Corrected links to use the [Preferred Citation Format](https://github.com/ethereum/EIPs/blob/a53796fb48328ec3c491e1222b6e707801e4fe87/README.md#preferred-citation-format).

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/GM2wWSt.jpg)
